### PR TITLE
feat: admin mode for activity registration (teacher login required)

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,10 @@
+[
+  {
+    "username": "teacher1",
+    "password": "password123"
+  },
+  {
+    "username": "teacher2",
+    "password": "password456"
+  }
+]


### PR DESCRIPTION
Implements Admin Mode:
- Only teachers (admins) can register or unregister students for activities, using credentials from teachers.json.
- Adds secure authentication using HTTP Basic Auth.
- Provides an /admin/login endpoint for admin login.

Closes #5.